### PR TITLE
Added self.deviceName in BLESession and other small changes

### DIFF
--- a/scratch_link.py
+++ b/scratch_link.py
@@ -525,8 +525,7 @@ class BLESession(Session):
             self.device = self.found_devices[params['peripheralId']]
             self.deviceName = self.device.getValueText(0x9) or self.device.getValueText(0x8)
             try:
-                self.perip = Peripheral(self.device.addr,
-                                        self.device.addrType)
+                self.perip = Peripheral(self.device)
                 logger.info(f"connected to the BLE peripheral: {self.deviceName}")
             except BTLEDisconnectError as e:
                 logger.error(f"failed to connect to the BLE device \"{self.deviceName}\": {e}")

--- a/scratch_link.py
+++ b/scratch_link.py
@@ -465,16 +465,6 @@ class BLESession(Session):
                 logger.error("name/manufactureData filters not implemented")
                 # TODO: implement other filters defined:
                 # ref: https://github.com/LLK/scratch-link/blob/develop/Documentation/BluetoothLE.md
-            if 'namePrefix' in f:
-                # 0x08: Shortened Local Name
-                deviceName = dev.getValueText(0x08)
-                if not deviceName:
-                    continue
-                logger.debug(f"Name of \"{deviceName}\" begins with: \"{f['namePrefix']}\"?")
-                if(deviceName.startswith(f['namePrefix'])):
-                    logger.debug("Yes")
-                    return True
-                logger.debug("No")
         return False
 
     def _get_service(self, service_id):

--- a/scratch_link.py
+++ b/scratch_link.py
@@ -60,7 +60,7 @@ class Session():
     async def recv_request(self):
         """
         Handle a request from Scratch through websocket.
-        Return True when the sessino should end.
+        Return True when the session should end.
         """
         logger.debug("start recv_request")
         try:
@@ -116,7 +116,7 @@ class Session():
         await self.websocket.send(notification)
 
     async def handle(self):
-        logger.debug("start session hanlder")
+        logger.debug("start session handler")
         await self.recv_request()
         await asyncio.sleep(0.1)
         while True:
@@ -354,7 +354,7 @@ class BLESession(Session):
                     for d in devices:
                         params = { 'rssi': d.rssi }
                         params['peripheralId'] = devices.index(d)
-                        params['name'] = d.getValueText(0x9)
+                        params['name'] = d.getValueText(0x9) or d.getValueText(0x8)
                         self.session.notify('didDiscoverPeripheral', params)
                     time.sleep(1)
                 elif self.session.status == self.session.CONNECTED:
@@ -418,7 +418,7 @@ class BLESession(Session):
     def close(self):
         self.status = self.DONE
         if self.perip:
-            logger.info(f"disconnect to BLE peripheral: {self.perip}")
+            logger.info(f"disconnect from the BLE peripheral: {self.perip}")
             self.perip.disconnect()
 
     def __del__(self):
@@ -525,9 +525,9 @@ class BLESession(Session):
             try:
                 self.perip = Peripheral(self.device.addr,
                                         self.device.addrType)
-                logger.info(f"connect to BLE peripheral: {self.perip}")
+                logger.info(f"connected to the BLE peripheral: {self.perip}")
             except BTLEDisconnectError as e:
-                logger.error(f"failed to connect to BLE device: {e}")
+                logger.error(f"failed to connect to the BLE device: {e}")
                 self.status = self.DONE
 
             if self.perip:
@@ -660,4 +660,3 @@ while True:
         break
     except Exception as e:
         logger.info("Restarting scratch-link...")
-

--- a/scratch_link.py
+++ b/scratch_link.py
@@ -361,7 +361,7 @@ class BLESession(Session):
                             logger.debug("getting lock for waitForNotification")
                             with self.session.lock:
                                 logger.debug("before waitForNotification")
-                                self.session.perip.waitForNotifications(1.0)
+                                self.session.perip.waitForNotifications(0.0001)
                                 logger.debug("after waitForNotification")
                             logger.debug("released lock for waitForNotification")
                         except Exception as e:


### PR DESCRIPTION
When logging the device it may be more useful to have the name print rather than "<bluepy.btle.Peripheral object at 0x************>"
The shorter device name will be used if the long name is not defined

Passing the device variable itself into Peripheral() will give the addr, addrType and the iface to the Peripheral()
and if a device doesn't have a long name defined it will use the short one in params['name']

Fixed some spelling mistakes